### PR TITLE
fix pre background reset by host style

### DIFF
--- a/src/css/includes/_transit_result.scss
+++ b/src/css/includes/_transit_result.scss
@@ -14,9 +14,9 @@
   }
 
   h6, code, pre {
-    border: none;
-    background: none;
-    color: inherit;
+    border: none !important;
+    background-color: transparent !important;
+    color: inherit !important;
     padding: 0;
     margin: 0;
     text-transform: none;


### PR DESCRIPTION
## bug:
In `https://docs.docker.com/`, the style of `pre`will be reset by the doc's style. 

## why

It has a style like this: 
background-color: #F5F8FA !important;
